### PR TITLE
Fixed "Allow Minors" Switch

### DIFF
--- a/app/server/models/User.js
+++ b/app/server/models/User.js
@@ -342,7 +342,6 @@ schema.statics.getByToken = function(token, callback){
 schema.statics.validateProfile = function(profile, cb){
   return cb(!(
     profile.name.length > 0 &&
-    profile.adult &&
     profile.school.length > 0 &&
     ['2017', '2018', '2019', '2020', '2021', '2022', '2023', '2024', '2025'].indexOf(profile.graduationYear) > -1 &&
     ['M', 'F', 'O', 'N'].indexOf(profile.gender) > -1


### PR DESCRIPTION
The User validation was checking is they were an adult, so now it doesn't check that.