### PR TITLE
Fix defaultResponse on api

### DIFF
--- a/app/server/routes/api.js
+++ b/app/server/routes/api.js
@@ -72,6 +72,7 @@ module.exports = function(router) {
     return function(err, data){
       if (err){
         // SLACK ALERT!
+
         if (process.env.NODE_ENV === 'production'){
           request
             .post(process.env.SLACK_HOOK,
@@ -91,13 +92,10 @@ module.exports = function(router) {
                     "``` \n"
                   })
                 }
-              },
-              function (error, response, body) {
-                return res.status(500).send({
-                  message: "Your error has been recorded, we'll get right on it!"
-                });
               }
             );
+
+            return res.status(500).send(err);
         } else {
           return res.status(500).send(err);
         }


### PR DESCRIPTION
should record the error to slack and post the given message not just post the error to slack. It caused an issue where no matter what errors would just say "Your error has been recorded..." which doesn't seeem to be the intent
